### PR TITLE
Fix FindCredentials size on windows

### DIFF
--- a/src/keytar_win.cc
+++ b/src/keytar_win.cc
@@ -216,7 +216,7 @@ KEYTAR_OP_RESULT FindCredentials(const std::string& service,
     }
 
     std::string login = wideCharToAnsi(cred->UserName);
-    std::string password(reinterpret_cast<char*>(cred->CredentialBlob));
+    std::string password(reinterpret_cast<char*>(cred->CredentialBlob), cred->CredentialBlobSize);
 
     credentials->push_back(Credentials(login, password));
   }


### PR DESCRIPTION
`FindCredentials` was missing passing the `CredentialBlobSize` which resulted in an extra character at the end of the password for some values. Fixes: https://github.com/atom/node-keytar/issues/96